### PR TITLE
Fix publish workflow: move SBOM out of dist/

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,12 +62,23 @@ jobs:
       - name: Build sdist + wheel
         run: uv build
       - name: Produce SBOM (requirements-format)
-        run: uv export --format requirements-txt --no-dev --no-hashes --output-file dist/requirements.sbom.txt
+        # Do NOT write under `dist/`: `pypa/gh-action-pypi-publish`
+        # validates every file in `dist/` as a distribution and will
+        # fail on a non-wheel/sdist file.
+        run: |
+          mkdir -p sbom
+          uv export --format requirements-txt --no-dev --no-hashes --output-file sbom/requirements.sbom.txt
       - name: Upload distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: distributions
           path: dist/
+          if-no-files-found: error
+      - name: Upload SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom
+          path: sbom/
           if-no-files-found: error
 
   sign:
@@ -129,6 +140,11 @@ jobs:
         with:
           name: signed-distributions
           path: dist/
+      - name: Download SBOM
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sbom
+          path: sbom/
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
@@ -141,4 +157,4 @@ jobs:
             dist/*.whl
             dist/*.sigstore
             dist/*.sigstore.json
-            dist/requirements.sbom.txt
+            sbom/requirements.sbom.txt


### PR DESCRIPTION
## Summary

The 2.0.0 publish run ([run 24618885056](https://github.com/bsolomon1124/pyfinance/actions/runs/24618885056/job/71985894239)) failed at the **Publish to PyPI** step:

> \`Checking dist/requirements.sbom.txt: ERROR InvalidDistribution: Unknown distribution format: 'requirements.sbom.txt'\`

\`pypa/gh-action-pypi-publish\` validates **every** file under \`dist/\` as a Python distribution (wheel or sdist). We were writing the SBOM to \`dist/requirements.sbom.txt\`, so twine-style validation rejected it.

## Fix

- In the \`build\` job, write the SBOM to \`sbom/requirements.sbom.txt\` (outside \`dist/\`) and upload it as a separate \`sbom\` artifact.
- In the \`release\` job, download both \`signed-distributions\` and \`sbom\` artifacts and attach the SBOM to the GitHub Release from its own path.
- No change to PyPI upload content (wheel + sdist only).

## Test plan

- [ ] Bump version, tag \`v2.0.1\` after merge, confirm the publish workflow succeeds end-to-end.
- [ ] Verify the GitHub Release still has the SBOM attached alongside the Sigstore bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)