### PR TITLE
Fix publish: drop dead dist/*.sigstore glob

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -155,6 +155,5 @@ jobs:
           files: |
             dist/*.tar.gz
             dist/*.whl
-            dist/*.sigstore
             dist/*.sigstore.json
             sbom/requirements.sbom.txt


### PR DESCRIPTION
## Summary

The 2.0.0 re-run ([run 24619068858](https://github.com/bsolomon1124/pyfinance/actions/runs/24619068858/job/71986396404)) succeeded at PyPI upload but failed at the GitHub Release step:

> \`##[error]⚠️  Pattern 'dist/*.sigstore' does not match any files.\`

\`sigstore/gh-action-sigstore-python@v3\` only produces \`.sigstore.json\` bundle files. The older \`.sigstore\` format is v2-only. Because the release step sets \`fail_on_unmatched_files: true\`, an unmatched glob aborts the job.

## Fix

Remove the vestigial \`dist/*.sigstore\` entry from the release-files list. The \`.sigstore.json\` bundle is still attached.

## Test plan

- [x] After this and #31 are on \`master\`, bump to 2.0.1 and tag; confirm publish + release both succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)