### PR TITLE
Release 2.0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -155,6 +155,5 @@ jobs:
           files: |
             dist/*.tar.gz
             dist/*.whl
-            dist/*.sigstore
             dist/*.sigstore.json
             sbom/requirements.sbom.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-04-19
+
+Re-release of 2.0.0 to work around two bugs in the publish workflow
+that blocked the 2.0.0 GitHub Release from completing. The published
+PyPI package content is identical to 2.0.0.
+
+### Fixed
+
+- `publish.yml`: the SBOM was being written to
+  `dist/requirements.sbom.txt`, where `pypa/gh-action-pypi-publish`
+  applied twine-style validation to it and failed with
+  `InvalidDistribution: Unknown distribution format`. SBOM is now
+  written to `sbom/requirements.sbom.txt`, uploaded as a separate
+  artifact, and attached to the GitHub Release from its own path.
+- `publish.yml`: removed a vestigial `dist/*.sigstore` glob from the
+  release-files list. `sigstore/gh-action-sigstore-python@v3`
+  produces only `.sigstore.json` bundle files; the empty glob was
+  aborting the release step because `fail_on_unmatched_files: true`.
+
 ## [2.0.0] - 2026-04-18
 
 ### Added
@@ -222,7 +241,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Thorough PEP 8 linting via flake8.
 
-[Unreleased]: https://github.com/bsolomon1124/pyfinance/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/bsolomon1124/pyfinance/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/bsolomon1124/pyfinance/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/bsolomon1124/pyfinance/compare/v1.3.0...v2.0.0
 [1.3.0]: https://github.com/bsolomon1124/pyfinance/compare/v1.2.5...v1.3.0
 [1.2.5]: https://github.com/bsolomon1124/pyfinance/compare/v1.2.4...v1.2.5

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ statistical toolkit.
 
 ## Status
 
-- **Latest release:** 2.0.0
+- **Latest release:** 2.0.1
 - **Python:** 3.10, 3.11, 3.12, 3.13, 3.14
 - **License:** MIT
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "pyfinance"
-version = "2.0.0"
+version = "2.0.1"
 description = "Python package designed for security returns analysis."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1218,7 +1218,7 @@ wheels = [
 
 [[package]]
 name = "pyfinance"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

Re-release of 2.0.0 to work around the publish-workflow bugs fixed in #31 and #32. Published package content is identical to 2.0.0.

## Stacking note

This PR is stacked on #32. Merge order:

1. #32 (remove dead \`dist/*.sigstore\` glob)
2. This PR (bump to 2.0.1)

GitHub should automatically update this PR's base once #32 merges. If it doesn't, a rebase onto \`master\` will produce a clean diff.

## Changes

- \`pyproject.toml\` → \`version = "2.0.1"\`
- \`uv.lock\` re-resolved (pyfinance 2.0.0 → 2.0.1 self-reference)
- \`README.md\` status line bumped
- \`CHANGELOG.md\` new \`[2.0.1]\` section summarizing the publish-workflow fixes, plus a new compare-URL reference link

## Verification

- \`uv run pytest\` → **126 passed, 1 skipped** locally
- \`uv build\` → produces \`pyfinance-2.0.1.tar.gz\` + \`pyfinance-2.0.1-py3-none-any.whl\`

## Release procedure after merge

\`\`\`bash
git checkout master && git pull
git tag v2.0.1
git push origin v2.0.1
\`\`\`

The tag push triggers \`.github/workflows/publish.yml\`. The publish step runs in the \`pypi\` GitHub Environment — approve the deployment if required-reviewers is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)