### PR TITLE
Fix semi_stdev (#15) and rsq/rsq_adj no-intercept (#13); release 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `sqrt( sum(min(x - t, 0)^2) / (n - ddof) )`. This also affected any
   downstream ratio that consumes semi-stdev. Thanks to @AlessandroQI
   for the original report (#15).
+- `pyfinance.ols.OLS.rsq` / `.rsq_adj` and the rolling equivalents
+  were built around the centered total-sum-of-squares identity
+  `SS_reg + SS_err = SS_tot`, which only holds when the model has an
+  intercept. With `use_const=False` this produced nonsensical values
+  (e.g. `rsq=[938, 868, 801]` in the repro from #13). The no-intercept
+  branch now uses the uncentered form `R² = 1 - SS_err / sum(y²)`
+  with `rsq_adj = 1 - (1 - R²) * n / (n - k)`. Fix attributed to
+  @zhangda425's report (#13).
+- `pyfinance.ols._rolling_lstsq`: used a bare `np.squeeze(...)` that
+  collapsed the predictor-count axis (`k`) when there was a single
+  predictor, producing a 1-d `solution` that broke `_predicted`,
+  `_resids`, and every rsq / residual statistic on 1-predictor rolling
+  regressions. Now squeezes only the trailing axis (the one introduced
+  by `np.atleast_3d(y)`). **Note:** for `RollingOLS(..., use_const=False)`
+  with a single predictor, `r.beta` is now shape `(n_windows, 1)` where
+  previously it was `(n_windows,)`. Call `r.beta.squeeze()` for the
+  old shape.
 
 ### Added
 
 - Regression tests pinning the exact `semi_stdev` formula, its `ddof`
   behavior, and threshold monotonicity.
+- Regression tests covering the no-intercept `rsq` / `rsq_adj` fix for
+  both `OLS` and `RollingOLS`, plus a shape pin for the 1-predictor
+  rolling solution.
 
 ## [2.0.1] - 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-04-19
+
+### Fixed
+
+- `pyfinance.returns.TSeries.semi_stdev`: the `/ n` denominator was
+  outside the square root, so the function returned values roughly an
+  order of magnitude smaller than the documented formula
+  `sqrt( sum(min(x - t, 0)^2) / (n - ddof) )`. This also affected any
+  downstream ratio that consumes semi-stdev. Thanks to @AlessandroQI
+  for the original report (#15).
+
+### Added
+
+- Regression tests pinning the exact `semi_stdev` formula, its `ddof`
+  behavior, and threshold monotonicity.
+
 ## [2.0.1] - 2026-04-19
 
 Re-release of 2.0.0 to work around two bugs in the publish workflow
@@ -241,7 +257,8 @@ PyPI package content is identical to 2.0.0.
 
 - Thorough PEP 8 linting via flake8.
 
-[Unreleased]: https://github.com/bsolomon1124/pyfinance/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/bsolomon1124/pyfinance/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/bsolomon1124/pyfinance/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/bsolomon1124/pyfinance/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/bsolomon1124/pyfinance/compare/v1.3.0...v2.0.0
 [1.3.0]: https://github.com/bsolomon1124/pyfinance/compare/v1.2.5...v1.3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,34 @@ task test-matrix   # or: for V in 3.10 3.11 3.12 3.13 3.14; ...
 Coverage is wired through `pytest-cov`; the 75 % floor is enforced by
 `--cov-fail-under=75` in `[tool.pytest.ini_options]`.
 
+## Before pushing: mandatory pre-push gauntlet
+
+CI runs **four** gates that can independently fail, and `ruff check`
+passing does **not** imply `ruff format --check` passes. Always run
+all four locally before pushing, in this order:
+
+```bash
+uv run ruff format        # REWRITES files — run first, review the diff
+uv run ruff check         # lint (separate from formatting)
+uv run pytest             # full suite + coverage gate
+uv run ty check           # type check (best-effort, not yet in CI)
+```
+
+Equivalent one-liner: `task check`.
+
+Or, preferred: run the full pre-commit suite so you catch everything
+CI checks plus markdownlint and the hygiene hooks:
+
+```bash
+uv run prek run --all-files
+```
+
+**Do not trust a passing `ruff check` to mean formatting is clean.**
+Past regressions: appending new tests without a subsequent
+`ruff format` run has silently broken CI's `ruff format --check` step
+twice. The `pre-commit` hook also catches this; install with
+`uv run prek install` to have it run on every commit.
+
 ## High-level architecture
 
 Six modules in `src/pyfinance/`. Public re-exports live in

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ statistical toolkit.
 
 ## Status
 
-- **Latest release:** 2.0.1
+- **Latest release:** 2.0.2
 - **Python:** 3.10, 3.11, 3.12, 3.13, 3.14
 - **License:** MIT
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "pyfinance"
-version = "2.0.1"
+version = "2.0.2"
 description = "Python package designed for security returns analysis."
 readme = "README.md"
 license = "MIT"

--- a/src/pyfinance/ols.py
+++ b/src/pyfinance/ols.py
@@ -63,12 +63,15 @@ def _rolling_lstsq(x, y):
         x = x[:, :, None]
     elif x.ndim <= 1:
         raise np.AxisError("x should have ndmi >= 2")
-    return np.squeeze(
-        np.matmul(
-            np.linalg.inv(np.matmul(x.swapaxes(1, 2), x)),
-            np.matmul(x.swapaxes(1, 2), np.atleast_3d(y)),
-        )
-    )
+    # Squeeze only the trailing axis (from `atleast_3d(y)` promoting y from
+    # shape `(n_windows, window)` to `(n_windows, window, 1)`). Using bare
+    # `np.squeeze` would also collapse the `k=1` axis when there is a single
+    # predictor, yielding a `(n_windows,)` solution that downstream code
+    # (e.g. `_predicted`) expects to be `(n_windows, k)`.
+    return np.matmul(
+        np.linalg.inv(np.matmul(x.swapaxes(1, 2), x)),
+        np.matmul(x.swapaxes(1, 2), np.atleast_3d(y)),
+    ).squeeze(axis=-1)
 
 
 def _confirm_constant(a):
@@ -291,15 +294,32 @@ class OLS:
 
     @property
     def rsq(self):
-        """The coefficent of determination, R-squared."""
-        return self.ss_reg / self.ss_tot
+        """The coefficent of determination, R-squared.
+
+        When the model contains an intercept, R² is defined against the
+        centered total sum of squares. With no intercept (`use_const=False`)
+        the identity `SS_reg + SS_err = SS_tot_centered` no longer holds,
+        so this falls back to the uncentered form
+        `1 - SS_err / sum(y**2)`.  See issue #13.
+        """
+        if self.use_const:
+            return self.ss_reg / self.ss_tot
+        ss_tot_uncentered = np.sum(np.square(self.y), axis=0)
+        return 1.0 - self.ss_err / ss_tot_uncentered
 
     @property
     def rsq_adj(self):
-        """Adjusted R-squared."""
+        """Adjusted R-squared.
+
+        With an intercept the denominator degrees-of-freedom is `n - k - 1`.
+        With no intercept there is no constant to subtract, so it becomes
+        `n - k`.
+        """
         n = self.n
         k = self.k
-        return 1.0 - ((1.0 - self.rsq) * (n - 1.0) / (n - k - 1.0))
+        if self.use_const:
+            return 1.0 - ((1.0 - self.rsq) * (n - 1.0) / (n - k - 1.0))
+        return 1.0 - ((1.0 - self.rsq) * n / (n - k))
 
     @property
     def _se_all(self):
@@ -405,6 +425,13 @@ class RollingOLS:
         )
         self.window = self.n = window
         self.xwins = utils.rolling_windows(self.x, window=window)
+        # `utils.rolling_windows` collapses a trailing singleton axis from
+        # `self.x` when k == 1, giving `xwins` shape `(n_windows, window)`
+        # instead of `(n_windows, window, 1)`.  Every consumer downstream
+        # (_predicted, _resids, _ss_*, _se_all) assumes the 3-d form, so
+        # restore it here.  See issue #13.
+        if self.xwins.ndim == 2:
+            self.xwins = self.xwins[:, :, None]
         self.ywins = utils.rolling_windows(self.y, window=window)
         self.solution = _rolling_lstsq(self.xwins, self.ywins)
         self.has_const = has_const
@@ -494,15 +521,23 @@ class RollingOLS:
 
     @property
     def _rsq(self):
-        """The coefficent of determination, R-squared."""
-        return self._ss_reg / self._ss_tot
+        """The coefficent of determination, R-squared.
+
+        See `OLS.rsq` for the `use_const=False` branch (issue #13).
+        """
+        if self.use_const:
+            return self._ss_reg / self._ss_tot
+        ss_tot_uncentered = np.sum(np.square(self.ywins), axis=1)
+        return 1.0 - self._ss_err / ss_tot_uncentered
 
     @property
     def _rsq_adj(self):
         """Adjusted R-squared."""
         n = self.n
         k = self.k
-        return 1.0 - ((1.0 - self._rsq) * (n - 1.0) / (n - k - 1.0))
+        if self.use_const:
+            return 1.0 - ((1.0 - self._rsq) * (n - 1.0) / (n - k - 1.0))
+        return 1.0 - ((1.0 - self._rsq) * n / (n - k))
 
     @property
     def _ms_err(self):

--- a/src/pyfinance/returns.py
+++ b/src/pyfinance/returns.py
@@ -869,7 +869,9 @@ class TSeries(pd.Series):
                 raise FrequencyError("Could not infer `freq`; pass it explicitly.")
         factor = utils.get_anlz_factor(freq)
         n = self.count() - ddof
-        ss = (nansum(np.minimum(self - threshold, 0.0) ** 2) ** 0.5) / n
+        # Formula: sqrt( sum(min(x - t, 0)^2) / (n - ddof) ).
+        # Previously the `/ n` was incorrectly outside the sqrt.  See #15.
+        ss = (nansum(np.minimum(self - threshold, 0.0) ** 2) / n) ** 0.5
         return ss * factor**0.5
 
     def sharpe_ratio(self, rf=0.02, ddof=0):

--- a/tests/test_ols.py
+++ b/tests/test_ols.py
@@ -1057,7 +1057,7 @@ def test_rsq_no_const_matches_uncentered_formula():
     y = x @ [0.8, -0.4, 1.1] + rng.normal(scale=0.1, size=n)
 
     model = ols.OLS(y=y, x=x, has_const=False, use_const=False)
-    expected = 1.0 - np.sum(model.resids ** 2) / np.sum(y ** 2)
+    expected = 1.0 - np.sum(model.resids**2) / np.sum(y**2)
     assert np.isclose(model.rsq, expected)
 
 
@@ -1093,8 +1093,6 @@ def test_rolling_single_predictor_beta_shape():
     """
     data = {"A": [2, 3, 4, 5, 6], "B": [10, 11, 12, 13, 14]}
     df = pd.DataFrame(data)
-    r = ols.RollingOLS(
-        y=df["B"], x=df["A"], window=3, has_const=False, use_const=False
-    )
+    r = ols.RollingOLS(y=df["B"], x=df["A"], window=3, has_const=False, use_const=False)
     assert r.solution.ndim == 2
     assert r.solution.shape == (3, 1)

--- a/tests/test_ols.py
+++ b/tests/test_ols.py
@@ -951,7 +951,11 @@ outs = (
 def test__rolling_lstsq(x, y, window, out):
     xwins = utils.rolling_windows(x, window)
     ywins = utils.rolling_windows(y, window)
-    assert np.allclose(ols._rolling_lstsq(xwins, ywins), out)
+    # `_rolling_lstsq` now preserves the k-dimension axis (see #13 fix);
+    # callers that used to rely on the implicit 1-d squeeze for k=1 need
+    # to squeeze explicitly now.
+    result = ols._rolling_lstsq(xwins, ywins)
+    assert np.allclose(result.squeeze(), out)
 
 
 def test_const_false():
@@ -1019,3 +1023,78 @@ def test_1d_x():
     )
     assert np.allclose(rolling.x, np.array([2, 3, 4, 5, 6])[:, None])
     assert np.allclose(rolling.y, np.array([10, 11, 12, 13, 14]))
+
+
+# ---------------------------------------------------------------------
+# Regression tests for issue #13: `rsq` / `rsq_adj` were returning
+# nonsensical values when the model had no intercept (`use_const=False`),
+# because the R^2 formula used centered TSS that only applies when a
+# constant is present.  After the fix, both the static and rolling
+# cases return values in [0, 1] for well-behaved inputs and stay
+# numerically close to the `use_const=True` fit on the same data when
+# the true relationship does pass through the origin.
+# ---------------------------------------------------------------------
+
+
+def test_rsq_no_const_in_unit_interval_static():
+    data = {"A": [2, 3, 4, 5, 6], "B": [10, 11, 12, 13, 14]}
+    df = pd.DataFrame(data)
+    model = ols.OLS(
+        y=df["B"].values,
+        x=df["A"].values,
+        has_const=False,
+        use_const=False,
+    )
+    assert 0.0 <= model.rsq <= 1.0
+
+
+def test_rsq_no_const_matches_uncentered_formula():
+    """R² without intercept should equal 1 - SS_err / sum(y^2)."""
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.normal(size=(n, 3))
+    # True relationship through the origin — ideal no-intercept fit.
+    y = x @ [0.8, -0.4, 1.1] + rng.normal(scale=0.1, size=n)
+
+    model = ols.OLS(y=y, x=x, has_const=False, use_const=False)
+    expected = 1.0 - np.sum(model.resids ** 2) / np.sum(y ** 2)
+    assert np.isclose(model.rsq, expected)
+
+
+def test_rsq_no_const_in_unit_interval_rolling():
+    # #13 exact repro: rsq used to return ~[938, 868, 801].
+    data = {"A": [2, 3, 4, 5, 6], "B": [10, 11, 12, 13, 14]}
+    df = pd.DataFrame(data)
+    rolling = ols.RollingOLS(
+        y=df["B"], x=df["A"], window=3, has_const=False, use_const=False
+    )
+    assert all(0.0 <= v <= 1.0 for v in rolling.rsq)
+
+
+def test_rsq_with_const_unchanged():
+    """Fix must not change the with-intercept branch."""
+    rng = np.random.default_rng(42)
+    n = 200
+    x = rng.normal(size=(n, 2))
+    y = 1.0 + x @ [1.5, -0.3] + rng.normal(scale=0.1, size=n)
+    model = ols.OLS(y=y, x=x, has_const=False, use_const=True)
+    # Expected: ss_reg / ss_tot using centered TSS.
+    yhat = model.predicted
+    ybar = y.mean()
+    expected = np.sum((yhat - ybar) ** 2) / np.sum((y - ybar) ** 2)
+    assert np.isclose(model.rsq, expected)
+
+
+def test_rolling_single_predictor_beta_shape():
+    """Regression: `_rolling_lstsq` used to squeeze the `k` axis for
+    single-predictor inputs, producing a 1-d `solution` that broke
+    downstream `_predicted`.  After the fix the solution is 2-d,
+    `(n_windows, k)`, for every k >= 1.
+    """
+    data = {"A": [2, 3, 4, 5, 6], "B": [10, 11, 12, 13, 14]}
+    df = pd.DataFrame(data)
+    r = ols.RollingOLS(
+        y=df["B"], x=df["A"], window=3, has_const=False, use_const=False
+    )
+    assert r.solution.ndim == 2
+    assert r.solution.shape == (3, 1)

--- a/tests/test_returns.py
+++ b/tests/test_returns.py
@@ -117,6 +117,56 @@ class TestTSeriesScalarStats:
     def test_semi_stdev_nonneg(self, daily_returns: TSeries):
         assert daily_returns.semi_stdev(freq="D") >= 0
 
+    def test_semi_stdev_matches_docstring_formula(self):
+        """Regression test for #15.
+
+        The docstring promises:
+            sqrt( sum(min(x - t, 0)^2) / (n - ddof) )
+
+        Until 2.0.1 the implementation placed `/ n` *outside* the sqrt,
+        yielding values an order of magnitude too small. Pin the exact
+        formula here so the bug cannot silently regress.
+        """
+        vals = [
+            -0.01, 0.02, -0.03, 0.01, -0.02,
+             0.03, -0.01, 0.02, -0.01, 0.01,
+        ]
+        idx = pd.date_range("2020-01-01", periods=len(vals), freq="D")
+        ts = TSeries(vals, index=idx)
+
+        n = len(vals)
+        downside_sq = sum(min(v, 0.0) ** 2 for v in vals)
+        expected_periodic = np.sqrt(downside_sq / n)
+        # `semi_stdev(freq='D')` annualizes by sqrt(252).
+        expected_anlzd = expected_periodic * np.sqrt(252.0)
+
+        assert np.isclose(ts.semi_stdev(freq="D"), expected_anlzd, rtol=1e-12)
+
+    def test_semi_stdev_respects_ddof(self):
+        """`ddof` should change the denominator to (n - ddof) inside sqrt."""
+        vals = [-0.02, 0.01, -0.03, 0.02, -0.01]
+        idx = pd.date_range("2020-01-01", periods=len(vals), freq="D")
+        ts = TSeries(vals, index=idx)
+
+        downside_sq = sum(min(v, 0.0) ** 2 for v in vals)
+        for ddof in (0, 1, 2):
+            expected = np.sqrt(downside_sq / (len(vals) - ddof)) * np.sqrt(252.0)
+            assert np.isclose(
+                ts.semi_stdev(ddof=ddof, freq="D"), expected, rtol=1e-12
+            )
+
+    def test_semi_stdev_threshold_shifts_downside(self):
+        """A positive threshold should strictly widen the downside mask."""
+        vals = [0.005, 0.02, -0.01, 0.03, 0.001]
+        idx = pd.date_range("2020-01-01", periods=len(vals), freq="D")
+        ts = TSeries(vals, index=idx)
+
+        # Against threshold=0 only the -0.01 observation is downside.
+        base = ts.semi_stdev(threshold=0.0, freq="D")
+        # Against threshold=0.01, the 0.005 and 0.001 obs become downside too.
+        higher = ts.semi_stdev(threshold=0.01, freq="D")
+        assert higher > base
+
     def test_sharpe_and_sortino_are_finite(self, daily_returns: TSeries):
         assert np.isfinite(daily_returns.sharpe_ratio())
         assert np.isfinite(daily_returns.sortino_ratio(freq="D"))

--- a/tests/test_returns.py
+++ b/tests/test_returns.py
@@ -128,8 +128,16 @@ class TestTSeriesScalarStats:
         formula here so the bug cannot silently regress.
         """
         vals = [
-            -0.01, 0.02, -0.03, 0.01, -0.02,
-             0.03, -0.01, 0.02, -0.01, 0.01,
+            -0.01,
+            0.02,
+            -0.03,
+            0.01,
+            -0.02,
+            0.03,
+            -0.01,
+            0.02,
+            -0.01,
+            0.01,
         ]
         idx = pd.date_range("2020-01-01", periods=len(vals), freq="D")
         ts = TSeries(vals, index=idx)
@@ -151,9 +159,7 @@ class TestTSeriesScalarStats:
         downside_sq = sum(min(v, 0.0) ** 2 for v in vals)
         for ddof in (0, 1, 2):
             expected = np.sqrt(downside_sq / (len(vals) - ddof)) * np.sqrt(252.0)
-            assert np.isclose(
-                ts.semi_stdev(ddof=ddof, freq="D"), expected, rtol=1e-12
-            )
+            assert np.isclose(ts.semi_stdev(ddof=ddof, freq="D"), expected, rtol=1e-12)
 
     def test_semi_stdev_threshold_shifts_downside(self):
         """A positive threshold should strictly widen the downside mask."""

--- a/uv.lock
+++ b/uv.lock
@@ -1218,7 +1218,7 @@ wheels = [
 
 [[package]]
 name = "pyfinance"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Closes #15. Closes #13.

## Summary

Two independent numerical bugs bundled into 2.0.2:

### #15 — `semi_stdev` formula

Was computing \`sqrt(sum(min(x-t, 0)^2)) / n\`; documented formula is \`sqrt(sum(min(x-t, 0)^2) / (n - ddof))\`. Move \`/ n\` inside the sqrt.

### #13 — R² blows past 1 when \`use_const=False\`

Three related fixes:

1. **\`rsq\` / \`rsq_adj\` formula.** \`SS_reg / SS_tot\` (centered) is only valid when a constant is in the model. No-intercept branch now uses \`1 - SS_err / sum(y**2)\` (uncentered R²), with \`rsq_adj = 1 - (1 - R²) * n / (n - k)\`.
2. **\`_rolling_lstsq\` squeeze bug.** Bare \`np.squeeze\` was collapsing the \`k\` axis when there was a single predictor, producing a 1-d \`solution\` that broke \`_predicted\` downstream. Squeeze only the trailing axis introduced by \`np.atleast_3d(y)\`.
3. **\`RollingOLS.__init__\` shape normalization.** \`utils.rolling_windows\` drops a trailing singleton, so a \`(n, 1)\` x produced \`(n_windows, window)\` windows instead of \`(n_windows, window, 1)\`. Restored at the constructor layer to avoid touching the widely-used utility.

Minor shape contract change (see CHANGELOG): \`RollingOLS(..., use_const=False)\` with a single predictor now returns \`r.beta\` of shape \`(n_windows, 1)\` where previously it was \`(n_windows,)\`.

## Verification

- \`uv run pytest\` → **134 passed, 1 skipped** (+8 new regression tests vs 2.0.1)
- Coverage: **75.43 %**, above the 75 % gate
- \`uv run ruff check\` → clean
- \`uv build\` → clean \`pyfinance-2.0.2\` wheel + sdist
- \`#13\` exact repro now returns \`rsq = [0.964, 0.982, 0.990]\` (was \`[938.59, 868.33, 801.06]\`)
- \`#15\` formula pin + \`ddof\` + threshold-monotonicity tests all pass

## Release

Bumps to **2.0.2**. CHANGELOG \`[2.0.2]\` section documents both fixes and the rolling-beta shape change; compare-URL reference links updated; README status line bumped.

### Release procedure after merge

```bash
git checkout master && git pull
git tag -a v2.0.2 -m "Release 2.0.2"
git push origin v2.0.2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)