### PR TITLE
chore: rename LICENSE.txt to LICENSE, update copyright years

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `LICENSE.txt` renamed to `LICENSE`; copyright years updated to 2017–2026; author name normalized to "Brad Solomon".
+
 ## [2.0.2] - 2026-04-19
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,3 +197,7 @@ Two workflows, both with all third-party actions pinned to SHA256:
 
 Dependabot (`.github/dependabot.yml`) opens weekly PRs for
 `github-actions` SHAs and `uv` ecosystem updates.
+
+## Pull request titles
+
+Follow Conventional Commits format: `<type>: <description>` (e.g. `chore: update dependencies`, `fix: handle edge case`, `feat: add new statistic`).

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016, 2017, 2018 Bradley Solomon
+Copyright (c) 2017-2026 Brad Solomon
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pyfinance
 
 [![PyPI version](https://img.shields.io/pypi/v/pyfinance.svg)](https://pypi.org/project/pyfinance/)
-[![License: MIT](https://img.shields.io/pypi/l/pyfinance.svg)](https://github.com/bsolomon1124/pyfinance/blob/master/LICENSE.txt)
+[![License: MIT](https://img.shields.io/pypi/l/pyfinance.svg)](https://github.com/bsolomon1124/pyfinance/blob/master/LICENSE)
 [![Python versions](https://img.shields.io/pypi/pyversions/pyfinance.svg)](https://pypi.org/project/pyfinance/)
 
 pyfinance is a Python package for investment management and analysis of
@@ -140,4 +140,4 @@ release notes for details and migration guidance.
 
 ## License
 
-MIT — see [LICENSE.txt](LICENSE.txt).
+MIT — see [LICENSE](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "2.0.2"
 description = "Python package designed for security returns analysis."
 readme = "README.md"
 license = "MIT"
-license-files = ["LICENSE.txt"]
+license-files = ["LICENSE"]
 authors = [{ name = "Brad Solomon" }]
 requires-python = ">=3.10,<3.15"
 keywords = [


### PR DESCRIPTION
## Summary

- Renames `LICENSE.txt` → `LICENSE`
- Updates copyright years to 2017–2026, normalizes author name to "Brad Solomon"
- Updates `pyproject.toml`: `license-files = ["LICENSE"]` (PEP 639)
- Updates `README.md`: LICENSE.txt references → LICENSE